### PR TITLE
Adding Corsican translation to the website

### DIFF
--- a/po/co.po
+++ b/po/co.po
@@ -1,0 +1,1108 @@
+# This file is part from WinMerge <http://winmerge.org/>
+# Released under the "GNU General Public License"
+#
+# Maintainer:
+# * Patriccollu di Santa Maria è Sichè
+#
+# Translators:
+# * Patriccollu di Santa Maria è Sichè
+#
+msgid ""
+msgstr "Project-Id-Version: WinMerge in Corsican\n"
+"Report-Msgid-Bugs-To: http://bugs.winmerge.org\n"
+"POT-Creation-Date: 2020-12-22 22:32+0000\n"
+"PO-Revision-Date: \n"
+"Language-Team: Patriccollu di Santa Maria è Sichè\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-Basepath: ../htdocs\n"
+"X-Generator: Poedit 3.0\n"
+"Last-Translator: Patriccollu di Santa Maria è Sichè <https://github.com/Patriccollu/Lingua_Corsa-Infurmatica/#readme>\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: co\n"
+
+#: 404.php:9
+msgid "Error 404 (Page Not Found)"
+msgstr "Sbagliu 404 (A pagina ùn esiste micca)"
+
+#: 404.php:11
+msgid "Page Not Found..."
+msgstr "A pagina ùn esiste micca…"
+
+#: 404.php:12
+msgid ""
+"For some reason (mis-typed URL, faulty referral from another site, out-of-"
+"date search engine listing or we simply deleted a file) the page you were "
+"looking for could not be found."
+msgstr "Per certe raghjoni (un indirizzu falsu, una referenza gattiva da un altru situ, una lista à l’anticogna d’un mutore di ricerca, o ancu per via d’un schedariu squassatu) ùn si pò truvà a pagina chì vo circate."
+
+#: 404.php:13
+msgid ""
+"This site has recently undergone a major re-working, so that might explain "
+"why you got this page instead."
+msgstr "U situ hè statu attualizatu pocu fà cù una riscrittura impurtante, ciò chì pò spiegà chì vo ricevete piuttostu sta pagina."
+
+#: 404.php:15
+msgid "Were you looking for..."
+msgstr "Cosa circate…"
+
+#: 404.php:18 docs/index.php:7 docs/index.php:9 engine/page.inc:341
+msgid "Documentation"
+msgstr "Documentazione"
+
+#: 404.php:20 docs/index.php:10
+msgid "Manual"
+msgstr "Manuale"
+
+#: 404.php:22 docs/index.php:15 engine/engine.inc:19
+msgid "English"
+msgstr "Inglese"
+
+#: 404.php:23 docs/index.php:16 engine/engine.inc:26
+msgid "Japanese"
+msgstr "Giappunese"
+
+#: 404.php:26 docs/index.php:19 docs/releasenotes.php:7
+#: docs/releasenotes.php:10
+msgid "Release Notes"
+msgstr "Annutazioni di versione"
+
+#: 404.php:27 docs/changelog.php:7 docs/index.php:21
+msgid "Change Log"
+msgstr "Ghjurnale di i cambiamenti"
+
+#: 404.php:30 engine/page.inc:342
+msgid "Downloads"
+msgstr "Scaricamenti"
+
+#: 404.php:31 engine/page.inc:343 screenshots/index.php:7
+#: screenshots/index.php:9
+msgid "Screenshots"
+msgstr "Catture di screnu"
+
+#: 404.php:32 downloads/index.php:59 engine/page.inc:344
+#: source-code/index.php:11 source-code/index.php:13
+msgid "Source Code"
+msgstr "Codice di fonte"
+
+#: 404.php:33 engine/page.inc:345 index.php:90 support/index.php:7
+#: support/index.php:9
+msgid "Support"
+msgstr "Assistenza"
+
+#: 404.php:34 engine/page.inc:346 translations/index.php:7
+#: translations/index.php:9
+msgid "Translations"
+msgstr "Traduzzioni"
+
+#: docs/changelog.php:5
+msgid ""
+"The change log is a more complete list of changes in the last WinMerge "
+"releases."
+msgstr "U ghjurnale di i cambiamenti hè una lista più cumpleta di i cambiamenti in l’ultime versioni di WinMerge."
+
+#: docs/changelog.php:6
+msgid "WinMerge, change log, changes, release, tracker item, revision number"
+msgstr "WinMerge, ghjurnale di i cambiamenti, cambiamenti, versione, elementu di tracciamentu, numeru di revisione"
+
+#: docs/changelog.php:10
+msgid "The change log is currently not available..."
+msgstr "Attualmente, u ghjurnale di i cambiamenti ùn hè micca dispunibule…"
+
+#: docs/index.php:5
+msgid ""
+"Documentation from WinMerge like manual, release notes, change log and "
+"Development Wiki."
+msgstr "A documentazione da WinMerge cum’è u manuale in linea, l’annutazioni di versione, u ghjurnale di i cambiamenti è u Wiki di sviluppu."
+
+#: docs/index.php:6
+msgid ""
+"WinMerge, documentation, manual, release notes, known issues, change log, "
+"Development Wiki"
+msgstr "WinMerge, documentazione, manuale in linea, annutazioni di versione, prublemi cunnisciuti, ghjurnale di i cambiamenti, Wiki di sviluppu"
+
+#: docs/index.php:11
+#, c-format
+msgid ""
+"The <a href=\"%s\">manual</a> explains how to use WinMerge, and documents "
+"its capabilities and limitations."
+msgstr "U <a href=\"%s\">manuale in linea</a> spiega cumu impiegà WinMerge è da ditaglii nant’à e so capacità è limitazioni."
+
+#: docs/index.php:12
+msgid "It is currently available in the following languages:"
+msgstr "À st’ora, hè dispunibule in quelle lingue :"
+
+#: docs/index.php:20
+#, c-format
+msgid ""
+"The <a href=\"%1$s\">release notes</a> are a short summary of important "
+"changes, enhancements, bug fixes and <a href=\"%2$s\">known issues</a> in "
+"the current WinMerge release."
+msgstr "L’<a href=\"%1$s\">annutazioni di versione</a> sò un riassuntu cortu di i cambiamenti impurtante, amendamenti, currezzioni di prublemi è <a href=\"%2$s\">prublemi cunnisciuti</a> di a versione attuale di WinMerge."
+
+#: docs/index.php:22
+#, c-format
+msgid ""
+"The <a href=\"%s\">change log</a> is a more complete list of changes in the "
+"last WinMerge releases."
+msgstr "U <a href=\"%s\">ghjurnale di i cambiamenti</a> hè una lista più cumpleta di i cambiamenti in l’ultime versioni di WinMerge."
+
+#: docs/index.php:23
+msgid "Development Wiki"
+msgstr "Wiki di sviluppu"
+
+#: docs/index.php:24
+#, c-format
+msgid ""
+"The <a href=\"%s\">Development Wiki</a> contains much information about the "
+"WinMerge development."
+msgstr "U <a href=\"%s\">Wiki di sviluppu</a> cuntene più d’infurmazioni nant’à u sviluppu di WinMerge."
+
+#: docs/releasenotes.php:5
+msgid ""
+"The release notes are a short summary of important changes, enhancements, "
+"bug fixes and known issues in the current WinMerge release."
+msgstr "L’annutazioni di versione sò un riassuntu cortu di i cambiamenti impurtante, amendamenti, currezzioni di prublemi è prublemi cunnisciuti di a versione attuale di WinMerge."
+
+#: docs/releasenotes.php:6
+msgid ""
+"WinMerge, release notes, summary, changes, enhancements, bug fixes, known "
+"issues, release"
+msgstr "WinMerge, annutazioni di versione, riassuntu, cambiamenti, amendamenti, currezzioni di prublemi, prublemi cunnisciuti, versione"
+
+#: docs/releasenotes.php:11
+msgid "The release notes are currently not available..."
+msgstr "Attualmente, l’annutazioni di versione ùn sò micca dispunibule…"
+
+#: downloads/index.php:7
+#, c-format
+msgid ""
+"Download the current WinMerge version %1$s, which was released at %2$s. For "
+"detailed info on what is new, read the change log and the release notes."
+msgstr "Scaricate a versione attuale %1$s di WinMerge chì hè stata publicata u %2$s. Per sapene di più nant’à ciò chì hè novu, fighjate u ghjurnale di i cambiamenti è l’annutazioni di versione."
+
+#: downloads/index.php:8
+msgid ""
+"WinMerge, free, download, Windows, setup, installer, binaries, runtimes, "
+"stable, beta, experimental, portable"
+msgstr "WinMerge, liberu, scaricà, Windows, cunfigurazione, stalladore, binarii, schedarii d’esecuzione, stabule, beta, esperimentale, purtavule"
+
+#: downloads/index.php:9 downloads/index.php:109
+msgid "Project File Releases"
+msgstr "Versioni di schedariu di prughjettu"
+
+#: downloads/index.php:10 downloads/index.php:12
+msgid "Download WinMerge"
+msgstr "Scaricà WinMerge"
+
+#: downloads/index.php:13
+#, c-format
+msgid ""
+"The easiest way to install WinMerge is to download and run the Installer. "
+"Read the <a href=\"%s\">online manual</a> for help using it."
+msgstr "A manera a più simplice d’installà WinMerge hè di scaricà è di lancià u stalladore. Fighjate u <a href=\"%s\">manuale in linea</a> per aiutavvi à impiegallu."
+
+#: downloads/index.php:14
+#, c-format
+msgid "WinMerge %s"
+msgstr "WinMerge %s"
+
+#: downloads/index.php:15
+#, c-format
+msgid ""
+"The current WinMerge version is <strong>%1$s</strong> and was released at "
+"<strong>%2$s</strong>."
+msgstr "A versione attuale di WinMerge hè <strong>%1$s</strong> è hè stata publicata u <strong>%2$s</strong>."
+
+#: downloads/index.php:16
+#, c-format
+msgid ""
+"For detailed info on what is new, read the <a href=\"%1$s\">change log</a> "
+"and the <a href=\"%2$s\">release notes</a>."
+msgstr "Per sapene di più nant’à ciò chì hè novu, fighjate u <a href=\"%1$s\">ghjurnale di i cambiamenti</a> è l’<a href=\"%2$s\">annutazioni di versione</a>."
+
+#: downloads/index.php:21 source-code/index.php:43
+msgid "Download"
+msgstr "Scaricà"
+
+#: downloads/index.php:22
+msgid "Size"
+msgstr "Dimensione"
+
+#: downloads/index.php:23
+msgid "Type"
+msgstr "Tipu"
+
+#: downloads/index.php:24
+msgid "Format"
+msgstr "Furmatu"
+
+#: downloads/index.php:28 downloads/index.php:34 downloads/index.php:40
+#: downloads/index.php:46 downloads/index.php:52 downloads/index.php:58
+#, c-format
+msgid "%s MB"
+msgstr "%s Mo"
+
+#: downloads/index.php:29 downloads/index.php:41
+msgid "Installer"
+msgstr "Stalladore"
+
+#: downloads/index.php:30 downloads/index.php:36 downloads/index.php:42
+msgid "EXE"
+msgstr "EXE"
+
+#: downloads/index.php:35
+msgid "Per-user installer"
+msgstr "Stalladore à l’utilizatore"
+
+#: downloads/index.php:47 downloads/index.php:53
+msgid "Binaries"
+msgstr "Binarii"
+
+#: downloads/index.php:48 downloads/index.php:54
+msgid "ZIP"
+msgstr "ZIP"
+
+#: downloads/index.php:60
+msgid "7z"
+msgstr "7z"
+
+#: downloads/index.php:65
+msgid "SHA-256 Checksums"
+msgstr "Somme di cuntrollu SHA-256"
+
+#: downloads/index.php:82
+msgid "Requirements"
+msgstr "Cundizioni richieste"
+
+#: downloads/index.php:85
+msgid "32-bit installer: Microsoft Windows XP SP3 or newer"
+msgstr "Stalladore 32-bit : Microsoft Windows XP SP3 o più recente"
+
+#: downloads/index.php:86
+msgid "64-bit installer: Microsoft Windows 7 or newer"
+msgstr "Stalladore 64-bit : Microsoft Windows 7 o più recente"
+
+#: downloads/index.php:87
+msgid "Admin rights for the installer (except for Per-user installer)"
+msgstr "Diritti d’amministratore per u stalladore (fora di u stalladore à l’utilizatore)"
+
+#: downloads/index.php:90
+msgid "Other Versions"
+msgstr "Altre versioni"
+
+#: downloads/index.php:91
+msgid "WinMerge 2.14.0 <em>for Windows 2000</em>"
+msgstr "WinMerge 2.14.0 <em>per Windows 2000</em>"
+
+#: downloads/index.php:92
+msgid ""
+"WinMerge version 2.14.0 was the last version to ship with Microsoft Visual C+"
+"+ 2008 runtimes that support Windows 2000."
+msgstr "WinMerge versione 2.14.0 hè l’ultima versione distribuita cù i schedarii d’esecuzione di Microsoft Visual C++ 2008 chì accettanu Windows 2000."
+
+#: downloads/index.php:94 downloads/index.php:99
+#, c-format
+msgid "Get version %s"
+msgstr "Ottinite a versione %s"
+
+#: downloads/index.php:96
+msgid "WinMerge 2.12.4 <em>for Windows 95/98/ME/NT</em>"
+msgstr "WinMerge 2.12.4 <em>per Windows 95/98/ME/NT</em>"
+
+#: downloads/index.php:97
+msgid ""
+"WinMerge version 2.12.4 was the last version to ship with Microsoft Visual C+"
+"+ 2005 runtimes that support Windows 95/98/ME/NT. It was also the last "
+"version to ship with an ANSI version of WinMerge."
+msgstr "WinMerge versione 2.12.4 hè l’ultima versione distribuita cù i schedarii d’esecuzione di Microsoft Visual C++ 2005 chì accettanu Windows 95/98/ME/NT. Hè dinù l’ultima versione distribuita cù una versione ANSI di WinMerge."
+
+#: downloads/index.php:101
+msgid "Unofficial Versions"
+msgstr "Versioni micca ufficiale"
+
+#: downloads/index.php:104
+msgid "Continuous Integration Builds"
+msgstr "Custruzzioni d’integrazione in cuntinuu"
+
+#: downloads/index.php:105
+msgid "WinMerge Portable"
+msgstr "WinMerge purtavule"
+
+#: downloads/index.php:105
+msgid "(by PortableApps.com)"
+msgstr "(da PortableApps.com)"
+
+#: downloads/index.php:125 index.php:85
+msgid "Y-m-d"
+msgstr "d-m-Y"
+
+#: downloads/index.php:127
+msgid "View all file releases&hellip;"
+msgstr "Fighjà tutte e versioni di schedariu&hellip;"
+
+#: downloads/index.php:131
+msgid "Stable Versions"
+msgstr "Versioni stabule"
+
+#: downloads/index.php:132
+msgid "Beta Versions"
+msgstr "Versioni beta"
+
+#: downloads/index.php:133
+msgid "Experimental Builds"
+msgstr "Custruzzioni esperimentale"
+
+#: downloads/index.php:134
+msgid "All File Releases"
+msgstr "Tutte e versioni di schedariu"
+
+#: engine/engine.inc:20
+msgid "Basque"
+msgstr "Bascu"
+
+#: engine/engine.inc:21
+msgid "Catalan"
+msgstr "Catalanu"
+
+#: engine/engine.inc:22
+msgid "Dutch"
+msgstr "Neerlandese"
+
+#: engine/engine.inc:23
+msgid "Greek"
+msgstr "Grecu"
+
+#: engine/engine.inc:24
+msgid "German"
+msgstr "Tedescu"
+
+#: engine/engine.inc:25
+msgid "French"
+msgstr "Francese"
+
+#: engine/engine.inc:27
+msgid "Polish"
+msgstr "Pulunese"
+
+#: engine/engine.inc:28
+msgid "Portuguese (Brazil)"
+msgstr "Purtughese (Brasile)"
+
+#: engine/engine.inc:29
+msgid "Portuguese (Portugal)"
+msgstr "Purtughese (Purtugallu)"
+
+#: engine/engine.inc:30
+msgid "Russian"
+msgstr "Russiu"
+
+#: engine/engine.inc:31
+msgid "Spanish"
+msgstr "Spagnolu"
+
+#: engine/engine.inc:32
+msgid "Spanish (Venezuela)"
+msgstr "Spagnolu (Venezuela)"
+
+#: engine/engine.inc:33
+msgid "Slovenian"
+msgstr "Slovenianu"
+
+#: engine/engine.inc:34
+msgid "Swedish"
+msgstr "Svedese"
+
+#: engine/engine.inc:35
+msgid "Turkish"
+msgstr "Turcu"
+
+#: engine/page.inc:126 engine/page.inc:169
+msgid "You will see the difference…"
+msgstr "Viderete a sfarenza…"
+
+#: engine/page.inc:191
+msgid "Change Language"
+msgstr "Cambià di lingua"
+
+#: engine/page.inc:208
+msgid "Project Pages"
+msgstr "Pagine di prughjettu"
+
+#: engine/page.inc:211
+msgid "Archive"
+msgstr "Archiviu"
+
+#: engine/page.inc:215 support/index.php:25
+msgid "Donate"
+msgstr "Dunazione"
+
+#: engine/page.inc:295
+#, c-format
+msgid "Version %1$s; %2$s MB"
+msgstr "Versione %1$s; %2$s Mo"
+
+#: engine/page.inc:301
+msgid "Download Now!"
+msgstr "Scaricà subitu !"
+
+#: engine/page.inc:340
+msgid "Home"
+msgstr "Accolta"
+
+#: engine/page.inc:340
+msgid "WinMerge Home"
+msgstr "Pagina d’accolta di WinMerge"
+
+#: engine/page.inc:341
+msgid "WinMerge Documentation"
+msgstr "Documentazione di WinMerge"
+
+#: engine/page.inc:342
+msgid "WinMerge Downloads"
+msgstr "Scaricamenti di WinMerge"
+
+#: engine/page.inc:343
+msgid "WinMerge Screenshots"
+msgstr "Catture di screnu WinMerge"
+
+#: engine/page.inc:344
+msgid "WinMerge Source Code"
+msgstr "Codice di fonte di WinMerge"
+
+#: engine/page.inc:345
+msgid "WinMerge Support"
+msgstr "Assistenza WinMerge"
+
+#: engine/page.inc:346
+msgid "WinMerge Translations"
+msgstr "Traduzzioni WinMerge"
+
+#: index.php:6
+msgid ""
+"WinMerge is an Open Source differencing and merging tool for Windows. "
+"WinMerge can compare both folders and files, presenting differences in a "
+"visual text format that is easy to understand and handle."
+msgstr "WinMerge hè un attrezzu di paragone è di fusione à fonte aperta per Windows. WinMerge pò paragunà cartulari è schedarii è affissà e sfarenze in un furmatu di testu visuale chì hè capicitoghju è faciule à manighjà."
+
+#: index.php:7
+msgid ""
+"WinMerge, free, open source, Windows, windiff, diff, merge, compare, tool, "
+"utility, text, file, folder, directory, compare files, compare folders, "
+"merge files, merge folders, diff tool, merge tool, compare tool"
+msgstr "WinMerge, liberu, fonte aperta, Windows, windiff, diff, fusione, paragunà, attrezzu, utilitariu, testu, schedariu, cartulare, sfugliaghju, paragone di schedariu, paragone di cartulare, fusione di schedariu, fusione di cartulare, attrezzu di sfarenza, attrezzu di fusione, attrezzu di paragone"
+
+#: index.php:8 index.php:78
+msgid "Project News"
+msgstr "Nutizie di u prughjettu"
+
+#: index.php:12
+msgid "What is WinMerge?"
+msgstr "Cosa hè WinMerge ?"
+
+#: index.php:13
+#, c-format
+msgid ""
+"WinMerge is an <a href=\"%s\">Open Source</a> differencing and merging tool "
+"for Windows. WinMerge can compare both folders and files, presenting "
+"differences in a visual text format that is easy to understand and handle."
+msgstr "WinMerge hè un attrezzu di paragone è di fusione <a href=\"%s\">à fonte aperta</a> per Windows. WinMerge pò paragunà cartulari è schedarii è affissà e sfarenze in un furmatu di testu visuale chì hè capicitoghju è faciule à manighjà."
+
+#: index.php:15
+msgid "Screenshot"
+msgstr "Cattura di screnu"
+
+#: index.php:17 screenshots/index.php:11 screenshots/index.php:12
+msgid "File Comparison"
+msgstr "Paragone di schedariu"
+
+#: index.php:19
+#, c-format
+msgid "See the <a href=\"%s\">screenshots page</a> for more screenshots."
+msgstr "Fighjate a <a href=\"%s\">pagina di e catture di screnu</a> per vedene d’altre."
+
+#: index.php:21
+msgid "Features"
+msgstr "Funzioni"
+
+#: index.php:22
+msgid ""
+"WinMerge is highly useful for determining what has changed between project "
+"versions, and then merging changes between versions. WinMerge can be used as "
+"an external differencing/merging tool or as a standalone application."
+msgstr "WinMerge hè assai ghjuvevule per determinà ciò chì hà cambiatu trà parechje versioni di prughjettu è per fà una fusione di sti cambiamenti. WinMerge pò esse impiegatu, sia cum’è un attrezzu esternu di paragone o di fusione, sia cum’è un’appiecazione autonoma."
+
+#: index.php:23
+msgid ""
+"In addition, WinMerge has many helpful supporting features that make "
+"comparing, synchronising, and merging as easy and useful as possible:"
+msgstr "In più di què, WinMerge cuntene tante funzioni ghjuvevule per rende più faciule u paragone, a sincrunizazione è a fusione :"
+
+#: index.php:25
+msgid "General"
+msgstr "Generale"
+
+#: index.php:27
+msgid "Supports Microsoft Windows XP SP3 or newer"
+msgstr "Accetta Microsoft Windows XP SP3 o più recente"
+
+#: index.php:28
+msgid "Handles Windows, Unix and Mac text file formats"
+msgstr "Cunnosce i furmati di schedariu di testu Windows, Unix è Mac"
+
+#: index.php:29
+msgid "Unicode support"
+msgstr "Permette Unicode"
+
+#: index.php:30
+msgid "Tabbed interface"
+msgstr "Interfaccia à unghjette"
+
+#: index.php:32
+msgid "File Compare"
+msgstr "Paragone di schedariu"
+
+#: index.php:34 screenshots/index.php:15 screenshots/index.php:16
+msgid "3-way File Comparison"
+msgstr "Paragone di 3 schedarii"
+
+#: index.php:34 index.php:50 index.php:56
+msgid "New!"
+msgstr "Novu !"
+
+#: index.php:35
+msgid "Visual differencing and merging of text files"
+msgstr "Sfarenza visuale è fusione di schedarii di testu"
+
+#: index.php:36
+msgid "Flexible editor with syntax highlighting, line numbers and word-wrap"
+msgstr "Un editore ghjunchevule cù messa in evidenza di a sintassa, numeri di linea è ritornu autumaticu à a linea"
+
+#: index.php:37
+msgid "Highlights differences inside lines"
+msgstr "Sopralineamentu di e sfarenze trà e linee"
+
+#: index.php:38
+msgid "Difference pane shows current difference in two vertical panes"
+msgstr "U pannellu di e sfarenze presenta e sfarenze trà i dui pannelli verticali"
+
+#: index.php:39
+msgid "Location pane shows map of files compared"
+msgstr "U pannellu di a lucalizazione presenta a cartugrafia di i schedarii paragunati"
+
+#: index.php:40
+msgid "Moved lines detection"
+msgstr "Abbentata di e linee dispiazzate"
+
+#: index.php:42
+msgid "Folder Compare"
+msgstr "Paragone di cartulare"
+
+#: index.php:44
+msgid ""
+"Regular Expression based file filters allow excluding and including items"
+msgstr "Filtri di schedariu appughjati nant’à l’espressioni regulare permettenu l’esclusione è l’inclusione d’elementi"
+
+#: index.php:45
+msgid "Fast compare using file sizes and dates"
+msgstr "Paragone rapidu impieghendu e dimensioni è e date di schedariu"
+
+#: index.php:46
+msgid "Compares one folder or includes all subfolders"
+msgstr "Paraguneghja un cartulare o include tutti i sottucartulari"
+
+#: index.php:47
+msgid "Can show folder compare results in a tree-style view"
+msgstr "Pò affissà i risultati di paragone di cartulare in una vista di tipu arburiscenza"
+
+#: index.php:48
+msgid "3-way Folder Comparison"
+msgstr "Paragone di 3 cartulari"
+
+#: index.php:50
+msgid "Image Compare"
+msgstr "Paragone di fiura"
+
+#: index.php:52
+msgid "Support many types of images"
+msgstr "Accetta tanti tipi di fiure"
+
+#: index.php:53
+msgid "Can highlight the differences with blocks"
+msgstr "Pò indicà e sfarenze cù blocchi"
+
+#: index.php:54
+msgid "Overlaying of the pictures is possible"
+msgstr "L’accavalcatura di e fiure hè pussibule"
+
+#: index.php:56
+msgid "Table Compare"
+msgstr "Paragone di tavulone"
+
+#: index.php:58
+msgid "Shows CSV/TSV file contents in table format"
+msgstr "Affisseghja u cuntenutu di schedariu CSV/TSV in furmatu di tavulone"
+
+#: index.php:59
+msgid "Text can be wrapped for each column"
+msgstr "U testu pò esse messu à a linea per ogni culonna"
+
+#: index.php:61
+msgid "Version Control"
+msgstr "Cuntrollu di versione"
+
+#: index.php:63
+msgid "Creates patch files (Normal-, Context- and Unified formats)"
+msgstr "Creazione di schedarii di currezzione (furmati nurmale, cuntestu è unificatu)"
+
+#: index.php:64
+msgid "Resolve conflict files"
+msgstr "Scioglie i schedarii in cunflittu"
+
+#: index.php:66
+msgid "Other"
+msgstr "Altru"
+
+#: index.php:68
+msgid "Shell Integration (supports 64-bit Windows versions)"
+msgstr "Integrazione cù l’interfaccia Shell (accetta e versioni 64-bit Windows)"
+
+#: index.php:69
+msgid "Archive file support using 7-Zip"
+msgstr "Permette l’archiviera di schedariu cù 7-Zip"
+
+#: index.php:70
+msgid "Plugin support"
+msgstr "Accetta i moduli d’estensione"
+
+#: index.php:71
+msgid "Localizable interface"
+msgstr "Interfaccia in a vostra lingua"
+
+#: index.php:72
+#, c-format
+msgid "<a href=\"%s\">Online manual</a> and installed HTML Help manual"
+msgstr "<a href=\"%s\">Manuale in linea</a> è manuale d’aiutu HTML installatu"
+
+#: index.php:75
+#, c-format
+msgid "WinMerge %s - latest stable version"
+msgstr "WinMerge %s - ultima versione stabule"
+
+#: index.php:76
+#, c-format
+msgid ""
+"<a href=\"%1$s\">WinMerge %2$s</a> is the latest stable version, and is "
+"recommended for most users."
+msgstr "<a href=\"%1$s\">WinMerge %2$s</a> hè l’ultima versione stabule chì hè ricumandata per a maiò parte di l’utilizatori."
+
+#: index.php:87
+msgid "View all news&hellip;"
+msgstr "Fighjà tutte e nutizie&hellip;"
+
+#: index.php:91
+#, c-format
+msgid ""
+"If you need support, look at our <a href=\"%s\">support page</a> for more "
+"information how you can get it."
+msgstr "S’è vo avete bisognu d’aiutu, fighjate a nostra <a href=\"%s\">pagina d’assistenza</a> per sapene di più nant’à a manera di l’ottene."
+
+#: index.php:93
+msgid "Developers"
+msgstr "Sviluppatori"
+
+#: index.php:94
+msgid ""
+"WinMerge is an open source project, which means that the program is "
+"maintained and developed by volunteers."
+msgstr "WinMerge hè un prughjettu à fonte aperta, vole si dì chì u prugramma hè sviluppatu è mantenutu da vuluntarii."
+
+#: index.php:95
+#, c-format
+msgid ""
+"In addition, WinMerge is translated into a number of different languages. "
+"See our <a href=\"%s\">information on translating WinMerge</a> into your own "
+"language."
+msgstr "In più di què, WinMerge hè traduttu in lingue numerose. Fighjate l’<a href=\"%s\">infurmazione nant’à cumu traduce WinMerge</a> in a vostra propia lingua."
+
+#: screenshots/index.php:5
+msgid ""
+"Screenshots from WinMerge features like file comparison, folder comparison "
+"results and location pane."
+msgstr "E catture di screnu di e funzioni WinMerge cum’è paragone di schedariu, risultati di paragone di cartulare è pannellu di lucalizazione."
+
+#: screenshots/index.php:6
+msgid ""
+"WinMerge, screenshots, file comparison, open-dialog, folder comparison "
+"results, highlight line diff, location pane, splash screen"
+msgstr "WinMerge, catture di screnu, paragone di schedariu, dialogu d’apertura, risultati di paragone di cartulare, messa in evidenza di e sfarenze di linea, pannellu di lucalizazione, screnu di benvenuta"
+
+#: screenshots/index.php:13
+msgid ""
+"File compare window is basically two files opened to editor into two "
+"horizontal panes. Editing allows user to easily do small changes without "
+"need to open files to other editor or development environment."
+msgstr "A finestra di paragone di schedariu hè un editore simplice di schedariu affissendu dui pannelli orizuntali cuntenendu i schedarii aperti. A funzione di mudificazione permette à l’utilizatore di fà chjuchi cambiamenti senza richiede d’apre i schedarii in un altru editore o in un ambiente di sviluppu."
+
+#: screenshots/index.php:17
+msgid ""
+"The 3-way file compare even allows comparing and editing three files at the "
+"same time."
+msgstr "U paragone di 3 schedarii permette di paragunà è di mudificà trè schedarii à u listessu tempu."
+
+#: screenshots/index.php:19 screenshots/index.php:20
+msgid "Folder Comparison Results"
+msgstr "Risultati di paragone di cartulare"
+
+#: screenshots/index.php:21
+msgid ""
+"Folder compare shows all files and subfolders found from compared folders as "
+"list. Folder compare allows synchronising folders by copying and deleting "
+"files and subfolders. Folder compare view can be versatile customised."
+msgstr "U paragone di cartulare presenta in una lista tutti i schedarii è sottucartulari trovi in i cartulari paragunati. Stu tipu di paragone permette a sincrunizazione di cartulari cupiendu è squassendu i schedarii è i sottucartulari. A vista di u paragone di cartulare pò esse assai persunalizata."
+
+#: screenshots/index.php:23 screenshots/index.php:24
+msgid "Folder Compare Tree View"
+msgstr "Vista in arburiscenza di paragonu di cartulare"
+
+#: screenshots/index.php:25
+msgid ""
+"In the tree view, folders are expandable and collapsible, containing files "
+"and subfolders. This is useful for an easier navigation in deeply nested "
+"directory structures. <em>The tree view is available only in recursive "
+"compares."
+msgstr "In a vista in arburiscenza, si pò esplurà i schedarii è i sottucartulari spieghendu è ripieghendu i cartulari. Què hè ghjuvevule per una navigazione più faciule in e strutture di cartulare più prufonde è incastrate. <em>A vista in arburiscenza hè dispunibule solu in i paragoni recursivi."
+
+#: screenshots/index.php:27 screenshots/index.php:28
+msgid "Image Comparison"
+msgstr "Paragone di fiura"
+
+#: screenshots/index.php:29
+msgid ""
+"WinMerge can compare images and highlight the differences in several ways."
+msgstr "WinMerge pò paragunà fiure è mette in evidenza e sfarenze di parechje manere."
+
+#: screenshots/index.php:31 screenshots/index.php:32
+msgid "Table Comparison"
+msgstr "Paragone di tavulone"
+
+#: screenshots/index.php:33
+msgid "Table compare shows the contents of CSV/TSV files in table format."
+msgstr "U paragone di tavulone presenta u cuntenutu di i schedarii CSV/TSV tale un tavulone."
+
+#: screenshots/index.php:35 screenshots/index.php:36
+msgid "Binary Comparison"
+msgstr "Paragone binariu"
+
+#: screenshots/index.php:37
+msgid ""
+"WinMerge can detect whether files are in text or binary format. When you "
+"launch a file compare operation on binary files, WinMerge opens each file in "
+"the binary file editor."
+msgstr "WinMerge pò abbentà s’è i schedarii sò in furmatu testu o binariu. Quandu vi lanciate un’operazione di paragone di schedariu nant’à schedarii binarii, WinMerge apre ogni schedariu in l’editore di schedariu binariu."
+
+#: screenshots/index.php:39 screenshots/index.php:40
+msgid "Open-dialog"
+msgstr "Dialogu d’apertura"
+
+#: screenshots/index.php:41
+msgid ""
+"WinMerge allows selecting/opening paths in several ways. Using the Open-"
+"dialog is just one of them."
+msgstr "WinMerge permette di selezziunà o d’apre i chjassi di parechje manere. Impiegà u dialogu d’apertura hè solu una di ste manere."
+
+#: source-code/index.php:8
+msgid ""
+"Download the source code of WinMerge, which is released under the GNU "
+"General Public License."
+msgstr "Scaricà u codice di fonte di WinMerge, chì hè distribuitu sottu à a licenza publica generale GNU."
+
+#: source-code/index.php:9
+msgid "WinMerge, free, clone, download, source code, GPL, GitHub, Git"
+msgstr "WinMerge, liberu, copia, doppiu, scaricà, codice di fonte, GPL, GitHub, Git"
+
+#: source-code/index.php:10 source-code/index.php:57
+msgid "Recent Commits"
+msgstr "Mudificazioni recente di fonte"
+
+#: source-code/index.php:15
+#, c-format
+msgid ""
+"WinMerge is <a href=\"%1$s\">Open Source</a> software under the <a href="
+"\"%2$s\">GNU General Public License</a>."
+msgstr "WinMerge hè un prugramma <a href=\"%1$s\">à fonte aperta</a> sottu à <a href=\"%2$s\">licenza publica generale GNU</a>."
+
+#: source-code/index.php:15
+#, c-format
+msgid ""
+"This means everybody can download the <a href=\"%s\">source code</a> and "
+"improve and modify it.\n"
+"The only thing we ask is that people submit their improvements and "
+"modifications back to us so that all WinMerge users may benefit."
+msgstr "Vole si dì chì ognunu pò scaricà u <a href=\"%s\">codice di fonte</a> per mudificallu è amendallu.\n"
+"A sola cosa chì no dumandemu hè chì a ghjente ci sottumetti i so mudificazioni è amendamenti è cusì l’utilizatori di WinMerge ponu prufittane."
+
+#: source-code/index.php:19
+msgid "GNU General Public License"
+msgstr "Licenza publica generale GNU"
+
+#: source-code/index.php:34
+msgid "Clone or download"
+msgstr "Duppià o scaricà"
+
+#: source-code/index.php:35
+#, c-format
+msgid ""
+"The source code is hosted on <a href=\"%1$s\">GitHub</a> in a <a href=\"%2$s"
+"\">Git</a> repository:"
+msgstr "U codice di fonte hè accoltu nant’à <a href=\"%1$s\">GitHub</a> in un cartulare<a href=\"%2$s\">Git</a> :"
+
+#: source-code/index.php:38
+msgid "You can also download the current branches as ZIP file:"
+msgstr "Si pò dinù scaricà e ghjembe attuale cum’è un schedariu ZIP :"
+
+#: source-code/index.php:44
+msgid "Branch"
+msgstr "Ghjemba"
+
+#: source-code/index.php:66
+msgid "Y-m-d H:i"
+msgstr "d-m-Y H:i"
+
+#: source-code/index.php:69
+msgid "View all commits&hellip;"
+msgstr "Fighjà tutte e mudificazioni recente di fonte&hellip;"
+
+#: support/index.php:5
+msgid "The Open Discussion forum is the fastest way to get help."
+msgstr "U foru di chjachjarata generale hè a manera a più rapida d’ottene un aiutu."
+
+#: support/index.php:6
+msgid ""
+"WinMerge, support, discussion forums, tracker, donate, bugs, support "
+"requests, patches, feature requests, todo, open source"
+msgstr "WinMerge, assistenza, fori di chjachjarata, tracciamentu, dunazione, prublemi, penseri, dumande, richieste, currezzioni, funzioni, fonte aperta"
+
+#: support/index.php:10
+msgid "The <b>Discussion forums</b> are the fastest way to get help:"
+msgstr "I fori di chjachjarata sò a manera a più rapida d’ottene un aiutu :"
+
+#: support/index.php:13
+msgid "WinMerge discussions"
+msgstr "Chjachjarate WinMerge"
+
+#: support/index.php:14
+msgid "Image Compare discussions"
+msgstr "Chjachjarate nant’à u paragone di fiura"
+
+#: support/index.php:15
+msgid "Website discussions"
+msgstr "Chjachjarate nant’à u situ web"
+
+#: support/index.php:17
+msgid "Please be patient, it may take some time for somebody to answer."
+msgstr "Per piacè, siate pazientosi, perchè si pò piglià un pocu di tempu chì qualchissia vi rispondi."
+
+#: support/index.php:19
+msgid "Issues"
+msgstr "Penseri"
+
+#: support/index.php:20
+#, c-format
+msgid "If you find a bug, please submit it as a <a href=\"%s\">issue</a>."
+msgstr "S’è vo scuprite un sbagliu o un prublema, dichjaratelu cum’è un <a href=\"%s\">penseru</a>."
+
+#: support/index.php:21
+msgid ""
+"Please attach as much information as you can: at a minimum, the version "
+"number of WinMerge that you are using. If you can, also attach a "
+"configuration log which, you can display by clicking <span class=\"guimenu"
+"\">Help</span> &#8594; <span class=\"guimenuitem\">Configuration</span> in "
+"the WinMerge window."
+msgstr "Ci vole à pruvede u più d’infurmazione pussibule ; a u minimu, u numeru di versione di WinMerge chì vo impiegate. S’ella si pò fà, mandate dinù un ghjurnale di cunfigurazione chì si pò affissà via <span class=\"guimenu\">Aiutu</span> &#8594; <span class=\"guimenuitem\">Cunfigurazione</span> in a finestra di WinMerge."
+
+#: support/index.php:22
+msgid ""
+"Good information in a bug report makes it more likely that your bug will be "
+"fixed quickly."
+msgstr "Un raportu di prublema cù infurmazioni detagliate hè aspessu a manera d’ottene in furia una currezzione."
+
+#: support/index.php:23
+#, c-format
+msgid ""
+"Wish list items on the <a href=\"%s\">issues list</a> will also be "
+"considered, but we make absolutely no promises."
+msgstr "L’elementi chì si trovanu nant’à a <a href=\"%s\">lista di i penseri</a> seranu apprezzati, ma ùn pudemu micca fà di prumessa."
+
+#: support/index.php:26
+#, c-format
+msgid ""
+"Since WinMerge is an <a href=\"%s\">Open Source</a> project, you may use it "
+"free of charge."
+msgstr "Cum’è WinMerge hè un prughjettu  <a href=\"%s\">à fonte aperta</a>, si pò impiegallu senza pagà."
+
+#: support/index.php:27
+#, c-format
+msgid ""
+"But please consider making a <a href=\"%s\">donation</a> to support the "
+"continued development of WinMerge."
+msgstr "Ma hè sempre bè di fà una <a href=\"%s\">dunazione</a> per sustene u sviluppu cuntinuu di WinMerge."
+
+#: support/index.php:29
+msgid "Buy WinMerge merchandise"
+msgstr "Cumprà a robba WinMerge"
+
+#: support/index.php:30
+#, c-format
+msgid ""
+"You can also support WinMerge by buying merchandise at the <a href=\"%s"
+"\">WinMerge CafePress store</a>. 20%% of the sales goes to WinMerge."
+msgstr "Pudete dinù sustene WinMerge cumprendu i prudutti nant’à a <a href=\"%s\">buttea CafePress di WinMerge</a>. 20%% di e vendite vanu à WinMerge."
+
+#: translations/index.php:6
+msgid "Translations Status"
+msgstr "Statu di e traduzzioni"
+
+#: translations/index.php:15 translations/index.php:36
+#: translations/status_website.php:14
+msgid "Translators"
+msgstr "Traduttori"
+
+#: translations/index.php:16
+msgid "WinMerge Status"
+msgstr "Statu di WinMerge"
+
+#: translations/index.php:17
+msgid "ShellExtension Status"
+msgstr "Statu di ShellExtension"
+
+#: translations/index.php:18 translations/index.php:45
+msgid "InnoSetup Files"
+msgstr "Schedarii InnoSetup"
+
+#: translations/index.php:19 translations/index.php:48
+msgid "Readme Files"
+msgstr "Schedarii Readme"
+
+#: translations/index.php:20
+msgid "Website Status"
+msgstr "Statu di u situ web"
+
+#: translations/index.php:21
+msgid "Instructions"
+msgstr "Istruzzioni"
+
+#: translations/index.php:24
+msgid "Translating"
+msgstr "Traduzzioni"
+
+#: translations/index.php:25
+msgid "We currently have WinMerge translated into the languages listed below:"
+msgstr "À st’ora, avemu traduttu WinMerge in quelle lingue :"
+
+#: translations/index.php:34
+#, c-format
+msgid ""
+"If you would like to update any of these translations or add another "
+"translation, then please follow <a href=\"%s\">these instructions</a>."
+msgstr "S’è vo vulete mudificà una di ste traduzzioni o aghjunghjene un’altra, seguitate <a href=\"%s\">st’istruzzioni</a>."
+
+#: translations/index.php:39
+#, c-format
+msgid "WinMerge Status <em>from %s</em>"
+msgstr "Statu di WinMerge <em>à u %s</em>"
+
+#: translations/index.php:42
+#, c-format
+msgid "ShellExtension Status <em>from %s</em>"
+msgstr "Statu di ShellExtension <em>à u %s</em>"
+
+#: translations/index.php:52 translations/status_website.php:21
+msgid "The translations status is currently not available..."
+msgstr "U statu di e traduzzioni ùn hè micca dispunibule attualmente…"
+
+#: translations/status_website.php:6 translations/status_website.php:8
+msgid "Translations Status (Website)"
+msgstr "Statu di e traduzzioni (situ web)"
+
+#: translations/status_website.php:9
+#, c-format
+msgid ""
+"We moved the sources from the website to a own <a href=\"%1$s\">GitHub "
+"repository</a>."
+msgstr "Avemu dispiazzatu e fonti da u situ web ver di u nostru propiu <a href=\"%1$s\">dipositu GitHub</a>."
+
+#: translations/status_website.php:17
+#, c-format
+msgid "Website Status <em>from %s</em>"
+msgstr "Statu di u situ web <em>à u %s</em>"
+
+#: translations/translations.inc:31
+msgid "File not valid."
+msgstr "U schedariu hè inaccettevule."
+
+#: translations/translations.inc:34
+msgid "File not found."
+msgstr "Ùn si pò truvà u schedariu."
+
+#: translations/translations.inc:74 translations/translations.inc:88
+#: translations/translations.inc:106
+msgid "Translated"
+msgstr "Traduttu"
+
+#: translations/translations.inc:74
+#, c-format
+msgid "Translated: %d%%"
+msgstr "Traduttu : %d%%"
+
+#: translations/translations.inc:76 translations/translations.inc:89
+#: translations/translations.inc:107
+msgid "Fuzzy"
+msgstr "Dubbitosu"
+
+#: translations/translations.inc:76
+#, c-format
+msgid "Fuzzy: %d%%"
+msgstr "Dubbitosu : %d%%"
+
+#: translations/translations.inc:78 translations/translations.inc:90
+#: translations/translations.inc:108
+msgid "Untranslated"
+msgstr "Micca traduttu"
+
+#: translations/translations.inc:78
+#, c-format
+msgid "Untranslated: %d%%"
+msgstr "Micca traduttu : %d%%"
+
+#: translations/translations.inc:104 translations/translations.inc:330
+msgid "Language"
+msgstr "Lingua"
+
+#: translations/translations.inc:105
+msgid "Graph"
+msgstr "Graficu"
+
+#: translations/translations.inc:109
+msgid "Last Update"
+msgstr "Ultima mudificazione"
+
+#: translations/translations.inc:150 translations/translations.inc:179
+#: translations/translations.inc:182
+msgid "Template"
+msgstr "Mudellu"
+
+#: translations/translations.inc:153
+#, c-format
+msgid "Total: %d"
+msgstr "Tutale : %d"
+
+#: translations/translations.inc:156
+msgid "Total: Unknown"
+msgstr "Tutale : Scunnisciutu"
+
+#: translations/translations.inc:310
+msgid "Maintainer"
+msgstr "Mantenitore"


### PR DESCRIPTION
Hello,

Corsican translation was added to WinMerge in yesterday's PR [#1072](https://github.com/WinMerge/winmerge/pull/1072).

Here is the **Corsican (co)** localization for the website.

Is there something else to update in order to have this brand new language available on website?

Best regards,
Patriccollu.