### PR TITLE
Include `?lang` in links

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -10,13 +10,13 @@
   $stablerelease = $page->getStableRelease();
   
   $page->printHeading(__('What is WinMerge?'));
-  $page->printPara(__('WinMerge is an <a href="%s">Open Source</a> differencing and merging tool for Windows. WinMerge can compare both folders and files, presenting differences in a visual text format that is easy to understand and handle.', 'source-code/'));
+  $page->printPara(__('WinMerge is an <a href="%s">Open Source</a> differencing and merging tool for Windows. WinMerge can compare both folders and files, presenting differences in a visual text format that is easy to understand and handle.', $translations->prepareLink('/source-code')));
 
   $page->printSubHeading(__('Screenshot'));
 ?>
 <p><img class="image" src="screenshots/filecmp.png" alt="<?php __e('File Comparison');?>" border="0"></p>
 <?php
-  $page->printPara(__('See the <a href="%s">screenshots page</a> for more screenshots.', 'screenshots/'));
+  $page->printPara(__('See the <a href="%s">screenshots page</a> for more screenshots.', $translations->prepareLink('/screenshots')));
 
   $page->printSubHeading(__('Features'));
   $page->printPara(__('WinMerge is highly useful for determining what has changed between project versions, and then merging changes between versions. WinMerge can be used as an external differencing/merging tool or as a standalone application.'));
@@ -73,7 +73,7 @@
 </ul>
 <?php
   $page->printSubHeading(__('WinMerge %s - latest stable version', $stablerelease->getVersionNumber()));
-  $page->printPara(__('<a href="%1$s">WinMerge %2$s</a> is the latest stable version, and is recommended for most users.', 'downloads/', $stablerelease->getVersionNumber()));
+  $page->printPara(__('<a href="%1$s">WinMerge %2$s</a> is the latest stable version, and is recommended for most users.', $translations->prepareLink('/downloads'), $stablerelease->getVersionNumber()));
 
   $page->printRssSubHeading(__('Project News'), 'https://sourceforge.net/export/rss2_projnews.php?group_id=13216');
   $feed = new SimplePie();
@@ -88,11 +88,11 @@
   print("</ul>\n");
 
   $page->printSubHeading(__('Support'));
-  $page->printPara(__('If you need support, look at our <a href="%s">support page</a> for more information how you can get it.', 'support/'));
+  $page->printPara(__('If you need support, look at our <a href="%s">support page</a> for more information how you can get it.', $translations->prepareLink('/support')));
 
   $page->printSubHeading(__('Developers'));
   $page->printPara(__('WinMerge is an open source project, which means that the program is maintained and developed by volunteers.'));
-  $page->printPara(__('In addition, WinMerge is translated into a number of different languages. See our <a href="%s">information on translating WinMerge</a> into your own language.', 'translations/'));
+  $page->printPara(__('In addition, WinMerge is translated into a number of different languages. See our <a href="%s">information on translating WinMerge</a> into your own language.', $translations->prepareLink('/translations')));
 
   $page->printFoot();
 ?>

--- a/htdocs/support/index.php
+++ b/htdocs/support/index.php
@@ -23,7 +23,7 @@
   $page->printPara(__('Wish list items on the <a href="%s">issues list</a> will also be considered, but we make absolutely no promises.', 'https://github.com/WinMerge/winmerge/issues'));
 
   $page->printSubHeading(__('Donate'));
-  $page->printPara(__('Since WinMerge is an <a href="%s">Open Source</a> project, you may use it free of charge.', '/source-code/'),
+  $page->printPara(__('Since WinMerge is an <a href="%s">Open Source</a> project, you may use it free of charge.', $translations->prepareLink('/source-code')),
                    __('But please consider making a <a href="%s">donation</a> to support the continued development of WinMerge.', 'https://sourceforge.net/project/project_donations.php?group_id=13216'));
 
   $page->printSubHeading(__('Buy WinMerge merchandise'));


### PR DESCRIPTION
Some links in page didn't include `?lang`. The user will be directed to the English version of the page. This PR attempts to fix it.

I'm not familiar with PHP, so this might not be the best solution.