### PR TITLE
WinMerge 2.16.50

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -35,7 +35,7 @@ ErrorDocument 404 /404.php
 </FilesMatch>
 
 #Redirect PAD download URL to current WinMerge version...
-Redirect permanent /downloads/WinMerge-Setup.exe https://downloads.sourceforge.net/winmerge/WinMerge-2.16.48.2-Setup.exe
+Redirect permanent /downloads/WinMerge-Setup.exe https://downloads.sourceforge.net/winmerge/WinMerge-2.16.50-Setup.exe
 
 #Redirect HTTP to HTTPS and www.winmerge.org to winmerge.org...
 RewriteEngine On

--- a/htdocs/engine/page.inc
+++ b/htdocs/engine/page.inc
@@ -43,19 +43,19 @@
       $this->_tab = TAB_HOME;
       /* _Stable Release */
       $this->_stablerelease = new Release;
-      $this->_stablerelease->setVersionNumber('2.16.48.2');
-      $this->_stablerelease->setDate('2025-04-29');
-      $this->_stablerelease->addDownload('setup.exe', __('x86 (32-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.48.2-Setup.exe', 10705448, '887038b3bee2a0aa1f0e93b4d0b4b8f065fb07d7ba06ff0dcb837d13c1a3a1e0');
-      $this->_stablerelease->addDownload('setup64.exe', __('x64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.48.2-x64-Setup.exe', 11224968, 'f8adc543b2dc722252b87b92bae982cce9083a642df30329419457a90484dfa3');
-      $this->_stablerelease->addDownload('setup64peruser.exe', __('x64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.48.2-x64-PerUser-Setup.exe', 11224056, 'b753b34258faf2272bf8bbbd4b34b63481f783b8ec2f2df5677f49880b9e7bfe');
-      $this->_stablerelease->addDownload('setuparm64.exe', __('ARM64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.48.2-ARM64-Setup.exe', 12199296, '9999b5cb5ca346144613bb48c5a6cb25fac3b53c1734dc2c157e06af99fa4006');
-      $this->_stablerelease->addDownload('exe.zip', __('x86 (32-bit)'), 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.48.2-exe.zip', 13417503, '5381cd226c3640c8244e2f2ede8ab12dbd79de135a1e474909ffdbc40dcc1962');
-      $this->_stablerelease->addDownload('exe64.zip', __('x64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.48.2-x64-exe.zip', 14182281, '1c87bae8cf1af3612a905fd6ceb86a02ce25f8acc44a21b8356b26e9f8567ef2');
-      $this->_stablerelease->addDownload('exearm64.zip', __('ARM64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.48.2-ARM64-exe.zip', 13605872, 'd8edead9216d602165e8c6e4fa47770b9aa6a5b91bd69904d101fffb11f77aa4');
-      $this->_stablerelease->addDownload('src.7z', '-', 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.48.2-full-src.7z', 16253605, 'bfe75b1565a62f603661e7c66e25386fe2d26bee61dc5477ab8b4b8e0712f5e9');
-      $this->_stablerelease->setReleaseNotes('https://github.com/WinMerge/winmerge/releases/tag/v2.16.48.2');
-      $this->_stablerelease->setKnownIssues('https://github.com/WinMerge/winmerge/releases/tag/v2.16.48.2#known-issues');
-      $this->_stablerelease->setChangeLog('https://github.com/WinMerge/winmerge/blob/v2.16.48.2/Docs/Users/ChangeLog.md');
+      $this->_stablerelease->setVersionNumber('2.16.50');
+      $this->_stablerelease->setDate('2025-07-27');
+      $this->_stablerelease->addDownload('setup.exe', __('x86 (32-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.50-Setup.exe', 11736088, '73ced7fd301f037f69328d6d490306a1695eabe1a144c62beea0823cf986688a');
+      $this->_stablerelease->addDownload('setup64.exe', __('x64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.50-x64-Setup.exe', 12276816, '1ed2819a990011a23838809d587891f52674c507e2ff63b8e97b4430e7484177');
+      $this->_stablerelease->addDownload('setup64peruser.exe', __('x64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.50-x64-PerUser-Setup.exe', 12276240, 'a20b1544c9ef87a49e93f5fb98ecd54053207bd1e106e915eb00a2425e18eb0b');
+      $this->_stablerelease->addDownload('setuparm64.exe', __('ARM64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.50-ARM64-Setup.exe', 13257904, '24c5d61d0886a4b8b860b2cfe7d55d875c0f5054f5c27ea508041bca1745273a');
+      $this->_stablerelease->addDownload('exe.zip', __('x86 (32-bit)'), 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.50-exe.zip', 14847721, 'e4f4a60ae6b458bc1817ee92705f4a19a4d2ca9d49c88dbeaa21e29d3cd5b460');
+      $this->_stablerelease->addDownload('exe64.zip', __('x64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.50-x64-exe.zip', 15592671, 'e2b6b13a9936f2e0f0d457944a333f7148cb26da2f859a110ab7dd9d13a2d5b0');
+      $this->_stablerelease->addDownload('exearm64.zip', __('ARM64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.50-ARM64-exe.zip', 15042169, 'b3524c7284acc90fe7f77071f23129e764d90ab6ce2b17d595d2a58fa8af8703');
+      $this->_stablerelease->addDownload('src.7z', '-', 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.50-full-src.7z', 16433241, 'dd59e0b59117b4c3f89d18fa8a71f7084b86be8812d3d709f2740398efaeae62');
+      $this->_stablerelease->setReleaseNotes('https://github.com/WinMerge/winmerge/releases/tag/v2.16.50');
+      $this->_stablerelease->setKnownIssues('https://github.com/WinMerge/winmerge/releases/tag/v2.16.50#known-issues');
+      $this->_stablerelease->setChangeLog('https://github.com/WinMerge/winmerge/blob/v2.16.50/Docs/Users/ChangeLog.md');
     }
 
     /**


### PR DESCRIPTION
Binaries have already been uploaded to both sourceforge.net and github.com.
This release adds support for filter expressions in the file mask field of folder comparison, allowing filtering by file size, modification date, content, and more.
The next stable release is scheduled for 2025-10-27.
