### PR TITLE
WinMerge 2.16.54.2

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -35,7 +35,7 @@ ErrorDocument 404 /404.php
 </FilesMatch>
 
 #Redirect PAD download URL to current WinMerge version...
-Redirect permanent /downloads/WinMerge-Setup.exe https://downloads.sourceforge.net/winmerge/WinMerge-2.16.54-Setup.exe
+Redirect permanent /downloads/WinMerge-Setup.exe https://downloads.sourceforge.net/winmerge/WinMerge-2.16.54.2-Setup.exe
 
 #Redirect HTTP to HTTPS and www.winmerge.org to winmerge.org...
 RewriteEngine On

--- a/htdocs/docs/index.php
+++ b/htdocs/docs/index.php
@@ -14,6 +14,7 @@
 ?>
 <ul class="buttons">
   <li><a href="https://manual.winmerge.org/en/" class="button is-small"><?php __e('English');?></a></li>
+  <li><a href="https://manual.winmerge.org/fr/" class="button is-small"><?php __e('French');?></a></li>
   <li><a href="https://manual.winmerge.org/he/" class="button is-small"><?php __e('Hebrew');?></a></li>
   <li><a href="https://manual.winmerge.org/jp/" class="button is-small"><?php __e('Japanese');?></a></li>
 </ul>

--- a/htdocs/engine/page.inc
+++ b/htdocs/engine/page.inc
@@ -43,19 +43,19 @@
       $this->_tab = TAB_HOME;
       /* _Stable Release */
       $this->_stablerelease = new Release;
-      $this->_stablerelease->setVersionNumber('2.16.54');
-      $this->_stablerelease->setDate('2026-01-27');
-      $this->_stablerelease->addDownload('setup.exe', __('x86 (32-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.54-Setup.exe', 10895784, 'a67220e5a8c5eb6da1791792939a5186bb474541ea9d5531abacc0713c4895b2');
-      $this->_stablerelease->addDownload('setup64.exe', __('x64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.54-x64-Setup.exe', 11377536, 'a63baed8eac4f5670ddd101e590fa9ab8ec53709948cbc470a0d14a156dc5632');
-      $this->_stablerelease->addDownload('setup64peruser.exe', __('x64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.54-x64-PerUser-Setup.exe', 11376960, 'd56398731b0e01a4a311897e47310a0103e979a5325964d7080c27aee3e8215a');
-      $this->_stablerelease->addDownload('setuparm64.exe', __('ARM64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.54-ARM64-Setup.exe', 12453808, '4fabd40f292f4aeadaede0bda98f62e24548783ca43793ee7a6205f5ab5ae1da');
-      $this->_stablerelease->addDownload('exe.zip', __('x86 (32-bit)'), 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.54-exe.zip', 13773487, '3d079061e43af4adf2a4b4aa271836fb4801c4ef017ad691d075c5ad244e2b56');
-      $this->_stablerelease->addDownload('exe64.zip', __('x64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.54-x64-exe.zip', 14430635, '08d09f3832cb15dd2298dd674531d5049d9345331a73c5be1fb2181395a0a6be');
-      $this->_stablerelease->addDownload('exearm64.zip', __('ARM64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.54-ARM64-exe.zip', 13973093, 'b1391edb679d282d266687686c1096f23d2c6f845576afc6bf57f644d64f5fc3');
-      $this->_stablerelease->addDownload('src.7z', '-', 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.54-full-src.7z', 16697858, 'c005df0beb207decc2440bd7052e0fab15eba53768aaac6175a6194fe6403de2');
-      $this->_stablerelease->setReleaseNotes('https://github.com/WinMerge/winmerge/releases/tag/v2.16.54');
-      $this->_stablerelease->setKnownIssues('https://github.com/WinMerge/winmerge/releases/tag/v2.16.54#known-issues');
-      $this->_stablerelease->setChangeLog('https://github.com/WinMerge/winmerge/blob/v2.16.54/Docs/Users/ChangeLog.md');
+      $this->_stablerelease->setVersionNumber('2.16.54.2');
+      $this->_stablerelease->setDate('2026-02-27');
+      $this->_stablerelease->addDownload('setup.exe', __('x86 (32-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.54.2-Setup.exe', 11977328, '77647e20eba4d511f2adde621bffc6588d0e991c41d2b138161a8557b9883f58');
+      $this->_stablerelease->addDownload('setup64.exe', __('x64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.54.2-x64-Setup.exe', 12459248, 'a205c9d6fa8426030b746dec34b5da0892e47c276bb4515a130c204c50036b2c');
+      $this->_stablerelease->addDownload('setup64peruser.exe', __('x64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.54.2-x64-PerUser-Setup.exe', 12458656, '94df15e679ad6a087808035b0dd750edef7b54729445b183253de42cfee571c9');
+      $this->_stablerelease->addDownload('setuparm64.exe', __('ARM64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/WinMerge-2.16.54.2-ARM64-Setup.exe', 13541184, '6aa1754010fa2aceab348e934452665921864983dba5b36f93c1960af8f2ac00');
+      $this->_stablerelease->addDownload('exe.zip', __('x86 (32-bit)'), 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.54.2-exe.zip', 14859722, '9463237ed5c8e4a4443f48c3a58e51ac09dc6b068f432478164f3beca9f3c847');
+      $this->_stablerelease->addDownload('exe64.zip', __('x64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.54.2-x64-exe.zip', 15518600, '3832f9db8d4d2210c3a049a8c30aed16ea152a329ae0c1b0dbf9308adbc9fc5e');
+      $this->_stablerelease->addDownload('exearm64.zip', __('ARM64 (64-bit)'), 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.54.2-ARM64-exe.zip', 15061101, 'a3a61d7cd60a7e6bf41e10a5405542e758c17724a912ca3330171e58ceb23c84');
+      $this->_stablerelease->addDownload('src.7z', '-', 'https://downloads.sourceforge.net/winmerge/winmerge-2.16.54.2-full-src.7z', 16970747, '716ec7e0d35480a29b3c95ff88824e1713c1fe4b6f5a3b261d8cd40e6de907fc');
+      $this->_stablerelease->setReleaseNotes('https://github.com/WinMerge/winmerge/releases/tag/v2.16.54.2');
+      $this->_stablerelease->setKnownIssues('https://github.com/WinMerge/winmerge/releases/tag/v2.16.54.2#known-issues');
+      $this->_stablerelease->setChangeLog('https://github.com/WinMerge/winmerge/blob/v2.16.54.2/Docs/Users/ChangeLog.md');
     }
 
     /**


### PR DESCRIPTION
This PR updates winmerge.org for WinMerge 2.16.54.2.
This is a bug-fix release; however, it also includes updated French documentation, so reflecting this change would be appreciated.
The binaries have already been uploaded to GitHub and SourceForge.